### PR TITLE
Feat: expose asset code/scale from connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ=="
     },
     "@types/node": {
-      "version": "10.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
-      "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.0.tgz",
+      "integrity": "sha512-R4Dvw6KjSYn/SpvjRchBOwXr14vVVcFXCtnM3f0aLvlJS8a599rrcEoihcP2/+Z/f75E5GNPd4aWM7j1yei9og=="
     },
     "@webassemblyjs/ast": {
       "version": "1.5.12",
@@ -3536,14 +3536,14 @@
       }
     },
     "ilp-protocol-stream": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/ilp-protocol-stream/-/ilp-protocol-stream-1.8.2.tgz",
-      "integrity": "sha512-GLP7/EhbKWVC39xFV3+uAdZhCeLDDju7cepYTWLdRzH1EJQFXTXbbDI02XrsiwThG3G3GWnnX4+zJZrKqEwuqQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-stream/-/ilp-protocol-stream-1.8.3.tgz",
+      "integrity": "sha512-FHe9DmMapETFeiG9A1zuL8H0Sp7/PCTeVHK4BNtMYcTt2PXAAjyzWbLp/CJF+ML0RCCVONQ5SDaSgEFgNu6/+w==",
       "requires": {
         "@types/node": "^10.7.1",
         "bignumber.js": "^7.2.1",
         "debug": "^4.0.0",
-        "ilp-logger": "^1.0.2",
+        "ilp-logger": "^1.1.2",
         "ilp-packet": "^3.0.0",
         "ilp-protocol-ildcp": "^2.0.0",
         "oer-utils": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2017": "^6.24.1",
     "fs-extra": "^6.0.1",
-    "ilp-protocol-stream": "^1.8.2",
+    "ilp-protocol-stream": "^1.8.3",
     "koa": "^2.5.1",
     "koa-router": "^7.4.0",
     "webpack": "^4.12.0",

--- a/src/web-connection.js
+++ b/src/web-connection.js
@@ -68,7 +68,7 @@ class WebIlpConnection extends EventTarget {
   }
 
   close () {
-    return this._connection.end()
+    return this._connection.destroy()
   }
 }
 

--- a/src/web-connection.js
+++ b/src/web-connection.js
@@ -27,6 +27,22 @@ class WebIlpConnection extends EventTarget {
     return new WebIlpStream({ stream })
   }
 
+  get sourceAssetScale () {
+    return this._connection.sourceAssetScale
+  }
+
+  get sourceAssetCode () {
+    return this._connection.sourceAssetCode
+  }
+
+  get destinationAssetScale () {
+    return this._connection.destinationAssetScale
+  }
+
+  get destinationAssetCode () {
+    return this._connection.destinationAssetCode
+  }
+
   get connectionTag () {
     return this._connection.connectionTag
   }

--- a/src/web-stream.js
+++ b/src/web-stream.js
@@ -68,7 +68,7 @@ class WebIlpStream extends EventTarget {
   }
 
   close () {
-    return this._stream.end()
+    return this._stream.destroy()
   }
 
   send (msg) {


### PR DESCRIPTION
- Exposes asset code and asset scale from ILP connection object
- Uses latest version of STREAM
- Uses `destroy` for close instead of `end` to ensure that the connection actually closes