### PR TITLE
feat: restructure

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,8 +44,13 @@ router.get('/is-registered.html', async ctx => {
 })
 
 router.get('/is-registered.js', async ctx => {
-  ctx.set('Content-Type', 'text/html')
+  ctx.set('Content-Type', 'text/javascript')
   ctx.body = await fs.readFile('./dist/is-registered.js', 'utf8')
+})
+
+router.get('/frame-call.js', async ctx => {
+  ctx.set('Content-Type', 'text/javascript')
+  ctx.body = await fs.readFile('./dist/frame-call.js', 'utf8')
 })
 
 app

--- a/src/frame-call-export.js
+++ b/src/frame-call-export.js
@@ -1,0 +1,4 @@
+const frameCall = require('./frame-call')
+
+window.WebMonetizationPolyfill = window.WebMonetizationPolyfill || {}
+window.WebMonetizationPolyfill.frameCall = window.WebMonetizationPolyfill.frameCall || frameCall

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,25 @@
-// TODO: should some of these libraries be deferred too?
-const frameCall = require('./frame-call')
 const WEB_MONETIZATION_DOMAIN = require('./web-monetization-domain')
 
 function loadElement (el) {
   return new Promise(resolve => el.addEventListener('load', resolve))
 }
 
-window.WebMonetization = window.WebMonetization || {}
-window.WebMonetization.register = window.WebMonetization.register || function registerWebMonetizationHandler ({ handlerUri, name }) {
+async function loadFrameCallScript () {
+  if (window.WebMonetizationPolyfill.frameCall) {
+    return window.WebMonetizationPolyfill.frameCall
+  }
+
+  const frameCallScript = document.createElement('script')
+  frameCallScript.src = WEB_MONETIZATION_DOMAIN + '/frame-call.js'
+  document.body.appendChild(frameCallScript)
+
+  await loadElement(frameCallScript)
+  document.body.removeChild(frameCallScript)
+  return window.WebMonetizationPolyfill.frameCall
+}
+
+window.WebMonetizationPolyfill = {}
+window.WebMonetizationPolyfill.register = function registerWebMonetizationHandler ({ handlerUri, name }) {
   const handler = encodeURIComponent(handlerUri)
   const iframeUrl = WEB_MONETIZATION_DOMAIN + '/register.html' +
     '?handler=' + handler +
@@ -35,13 +47,14 @@ window.WebMonetization.register = window.WebMonetization.register || function re
   })
 }
 
-window.WebMonetization.isRegistered = window.WebMonetization.isRegistered || async function isRegistered () {
+window.WebMonetizationPolyfill.isRegistered = async function isRegistered () {
   const isRegisteredFrame = document.createElement('iframe')
   isRegisteredFrame.src = WEB_MONETIZATION_DOMAIN + '/is-registered.html'
   isRegisteredFrame.style = 'display:none;'
   document.body.appendChild(isRegisteredFrame)
 
   await loadElement(isRegisteredFrame)
+  const frameCall = await loadFrameCallScript()
   const result = await frameCall({
     iframe: isRegisteredFrame,
     data: {},
@@ -52,22 +65,25 @@ window.WebMonetization.isRegistered = window.WebMonetization.isRegistered || asy
   return Boolean(result.registered)
 }
 
-window.WebMonetization.monetize = window.WebMonetization.monetize || async function createIlpConnection ({
+window.WebMonetizationPolyfill.monetize = async function createIlpConnection ({
   destinationAccount,
   sharedSecret
 }) {
-  if (window.WebMonetization._createConnection) {
-    const wmFrame = window.WebMonetization._wmFrame
-    return window.WebMonetization._createConnection({
+  if (window.WebMonetizationPolyfill.createConnection) {
+    const wmFrame = window.WebMonetizationPolyfill.wmFrame
+    return window.WebMonetizationPolyfill.createConnection({
       handlerFrame: wmFrame,
       destinationAccount,
       sharedSecret
     })
   }
 
+  // load frame call util
+  const frameCall = await loadFrameCallScript()
+
   // mount the iframe to webmonetization.org
   const wmFrame = document.createElement('iframe')
-  window.WebMonetization._wmFrame = wmFrame
+  window.WebMonetizationPolyfill.wmFrame = wmFrame
   wmFrame.src = WEB_MONETIZATION_DOMAIN + '/iframe.html' +
     '?origin=' + encodeURIComponent(window.location.origin)
   wmFrame.style = 'display:none;'
@@ -96,9 +112,14 @@ window.WebMonetization.monetize = window.WebMonetization.monetize || async funct
 
   // clean up the script element and init connection
   document.body.removeChild(streamScript)
-  return window.WebMonetization._createConnection({
+  return window.WebMonetizationPolyfill.createConnection({
     handlerFrame: wmFrame,
     destinationAccount,
     sharedSecret
   })
 }
+
+window.WebMonetization = window.WebMonetization || {}
+window.WebMonetization.register = window.WebMonetization.register || window.WebMonetizationPolyfill.register
+window.WebMonetization.isRegistered = window.WebMonetization.isRegistered || window.WebMonetizationPolyfill.isRegistered
+window.WebMonetization.monetize = window.WebMonetization.monetize || window.WebMonetizationPolyfill.monetize

--- a/src/stream.js
+++ b/src/stream.js
@@ -2,8 +2,8 @@ const IlpStream = require('ilp-protocol-stream')
 const WebIlpConnection = require('./web-connection')
 const Plugin = require('./plugin')
 
-window.WebMonetization = window.WebMonetization || {}
-window.WebMonetization._createConnection = async function ({
+window.WebMonetizationPolyfill = window.WebMonetizationPolyfill || {}
+window.WebMonetizationPolyfill.createConnection = async function ({
   handlerFrame,
   destinationAccount,
   sharedSecret,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
     'stream': './src/stream.js',
     'iframe': './src/iframe.js',
     'register': './src/register.js',
-    'is-registered': './src/is-registered.js'
+    'is-registered': './src/is-registered.js',
+    'frame-call': './src/frame-call-export.js'
   },
 
   output: {


### PR DESCRIPTION
- Pull out the frame call library (this changes the index script from 32k to 12k).
- Add `frame-call.js` to the polyfill's set of files in order to load the frame call library.
- Exports methods on `window.WebMonetizationPolyfill` and then sets them to be assigned on `window.WebMonetization` only if `window.WebMonetization` is not defined. This allows you to create polyfill scripts that wrap this polyfill, which is very useful for browser extensions.